### PR TITLE
Add format target for source code formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,105 @@
+Language:        Cpp
+BasedOnStyle:  Chromium
+AccessModifierOffset: 0
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit: 0
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeCategories:
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments: false
+SortIncludes: false
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        4
+UseTab: Never

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,3 +57,38 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
 install(TARGETS libblifparse blifparse_test DESTINATION bin)
+
+#
+# ----------------------- Code format --------------------------
+#
+
+set(code_format_files
+    -name '*.cpp' -print -o -name '*.h' -print
+    -o -name '*.tpp' -print -o -name '*.hpp' -print)
+
+set(code_format_dirs ${PROJECT_SOURCE_DIR}/src)
+
+#
+# Use clang-format-5.0 for code format
+#
+add_custom_target(format-cpp
+    COMMAND find ${code_format_dirs} ${code_format_files} |
+        xargs -P `nproc` clang-format-5.0 -style=file -i)
+
+#
+# Use simple python script for fixing C like boxed comments
+#
+add_custom_target(format-cpp-fix-comments DEPENDS format-cpp
+    COMMAND find ${code_format_dirs} ${code_format_files} |
+        xargs -L 1 -P `nproc`
+        python3 ${PROJECT_SOURCE_DIR}/scripts/format.py --inplace --fix-comments --input)
+
+#
+# Use simple python script for fixing template brackets e.g. <<>
+#
+add_custom_target(format-cpp-fix-template-operators DEPENDS format-cpp
+    COMMAND find ${code_format_dirs} ${code_format_files} |
+        xargs -L 1 -P `nproc`
+        python3 ${PROJECT_SOURCE_DIR}/scripts/format.py --inplace --fix-template-operators --input)
+
+add_custom_target(format DEPENDS format-cpp-fix-comments format-cpp-fix-template-operators)

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+import sys, os
+import argparse
+
+def fix_comments(f, o):
+    space_string = ''
+
+    for line in f:
+        # Skip lines with // comments
+        if space_string == '' and line.find('//') != -1:
+            o.write(line)
+            continue
+
+        sc = line.find("/*")
+        ec = line.find("*/")
+
+        # Skip /* foo bar */ comments
+        if sc != -1 and ec != -1:
+            o.write(line)
+        else:
+            # Start of /* comment */
+            if sc != -1:
+                space_string = (''.join(' ' for i in range(sc+1)))
+                o.write(line)
+            elif space_string != '':
+                # Already in /* comment */
+                ls = line.lstrip()
+
+                # Empty line, write aligned comment prefix
+                if len(ls) == 0:
+                    o.write(space_string + "*" + "\n")
+                elif ls[0] != '*':
+                    #
+                    # Fix comments like '********* sth **********'
+                    # to look like ' * ********** sth **********'
+                    #
+                    o.write(space_string + "* " + ls)
+                else:
+                    # Rest of the /* comment */
+                    o.write(space_string + ls)
+            else:
+                # Outside /* comment */
+                o.write(line)
+
+        # Moving outside /* comment */
+        if ec != -1:
+            space_string = ''
+
+def fix_template_operators(f, o):
+    for line in f:
+        line = line.replace('<<>', '< <>');
+        line = line.replace('><>', '> <>');
+        line = line.replace('==<>', '== <>');
+        line = line.replace('!=<>', '!= <>');
+
+        o.write(line);
+
+def main(argv):
+    parser = argparse.ArgumentParser(description='Tool for fixing clang code formatting')
+    parser.add_argument('--inplace', dest='inplace',
+        action='store_true',
+        help='Inplace edit specified file')
+    parser.add_argument('--fix-comments', dest='fix_comments',
+        action='store_const',
+        const='fix_comments',
+        help='Fix C like box comments')
+    parser.add_argument('--fix-template-operators', dest='fix_template_operators',
+        action='store_const',
+        const='fix_template_operators',
+        help='Fix C++ template operators e.g. operator<<> => operator< <>')
+    parser.add_argument('--input', dest='inputfile', action='store',
+        help='Input file')
+    parser.add_argument('--output', dest='outputfile', action='store',
+        help='Output file')
+    args = parser.parse_args(argv[1:]);
+
+    for p in args.fix_comments, args.fix_template_operators:
+        if not p:
+            continue
+
+        fin = open(args.inputfile, 'r')
+
+        if args.inplace:
+            fout = open(args.inputfile + '.bak', 'w')
+        else:
+            fout = open(args.outputfile, 'w');
+
+        eval('' + p + '(fin, fout)')
+
+        fin.close();
+        fout.close();
+
+        if args.inplace:
+            os.rename(args.inputfile + '.bak', args.inputfile)
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
This PR adds `make format` target which can be used to autoformat the code in the project. The target uses `clang-format-5.0` tool.
