### PR TITLE
Typos and Noop Default in `Callback`

### DIFF
--- a/src/blif_parser.y
+++ b/src/blif_parser.y
@@ -193,12 +193,12 @@ subckt: DOT_SUBCKT STRING       { $$ = SubCkt(); $$.model = $2; }
 latch: DOT_LATCH STRING STRING {
                                     //Input and output only
                                     callback.lineno(lexer.lineno()); 
-                                    callback.latch($2, $3, LatchType::UNSPECIFIED, "", LogicValue::UNKOWN);
+                                    callback.latch($2, $3, LatchType::UNSPECIFIED, "", LogicValue::UNKNOWN);
                                }
     | DOT_LATCH STRING STRING latch_type latch_control {
                                     //Input, output, type and control
                                     callback.lineno(lexer.lineno()); 
-                                    callback.latch($2, $3, $4, $5, LogicValue::UNKOWN);
+                                    callback.latch($2, $3, $4, $5, LogicValue::UNKNOWN);
                                }
     | DOT_LATCH STRING STRING latch_type latch_control latch_init {
                                     //Input, output, type, control and init-value
@@ -215,7 +215,7 @@ latch: DOT_LATCH STRING STRING {
 latch_init: LOGIC_TRUE { $$ = LogicValue::TRUE; }
     | LOGIC_FALSE { $$ = LogicValue::FALSE; }
     | LATCH_INIT_2 { $$ = LogicValue::DONT_CARE; }
-    | LATCH_INIT_3 { $$ = LogicValue::UNKOWN; }
+    | LATCH_INIT_3 { $$ = LogicValue::UNKNOWN; }
     ;
 
 latch_control: STRING { $$ = $1;}

--- a/src/blif_pretty_print.cpp
+++ b/src/blif_pretty_print.cpp
@@ -112,7 +112,7 @@ void BlifPrettyPrinter::latch(std::string input, std::string output, LatchType t
         case LogicValue::FALSE:     printf("%s0", indent().c_str()); break;
         case LogicValue::TRUE:      printf("%s1", indent().c_str()); break;
         case LogicValue::DONT_CARE: printf("%s2", indent().c_str()); break;
-        case LogicValue::UNKOWN:    printf("%s3", indent().c_str()); break;
+        case LogicValue::UNKNOWN:   printf("%s3", indent().c_str()); break;
         default: assert(false);
     }
     --indent_level_;

--- a/src/blifparse.hpp
+++ b/src/blifparse.hpp
@@ -105,10 +105,10 @@ void blif_parse_file(FILE* blif, Callback& callback, const char* filename="");
  * Enumerations
  */
 enum class LogicValue {
-    FALSE = 0,  //Logic zero
-    TRUE = 1,   //Logic one
-    DONT_CARE,     //Don't care
-    UNKOWN  //Unkown (e.g. latch initial state)
+    FALSE = 0,  // Logic zero
+    TRUE = 1,   // Logic one
+    DONT_CARE,  // Don't care
+    UNKNOWN     // Unknown (e.g. latch initial state)
 };
 
 enum class LatchType {

--- a/src/blifparse.hpp
+++ b/src/blifparse.hpp
@@ -7,16 +7,16 @@
  *
  * OVERVIEW
  * --------------------------
- * This library provides support for parsing Berkely Logic Interchange Format (BLIF)
- * files. It supporst the features required to handle basic netlists (e.g. .model, 
- * .inputs, .outputs, .subckt, .names, .latch)
+ * This library provides support for parsing Berkely Logic Interchange Format
+ * (BLIF) files. It supporst the features required to handle basic net lists
+ * (e.g. .model, .inputs, .outputs, .subckt, .names, .latch)
  *
  * USAGE
  * --------------------------
  * Define a callback derived from the blifparse::Callback interface, and pass it
  * to one of the blifparse::blif_parse_*() functions.
  *
- * The parser will then call the various callback methods as it encouters the 
+ * The parser will then call the various callback methods as it encounters the
  * appropriate parts of the netlist.
  *
  * See main.cpp and blif_pretty_print.hpp for example usage.
@@ -29,97 +29,112 @@
 #include <functional>
 
 namespace blifparse {
-/*
- * Data structure Forward declarations
- */
-enum class LogicValue;
-enum class LatchType;
+  /*
+   * Data structure Forward declarations
+   */
+  enum class LogicValue;
+  enum class LatchType;
 
-class Callback {
-    public:
-        virtual ~Callback() {}
+  class Callback {
+  public:
+    virtual ~Callback() {}
 
-        //Start of parsing
-        virtual void start_parse() = 0;
+    //Start of parsing
+    virtual void start_parse() {}
 
-        //Sets current filename
-        virtual void filename(std::string fname) = 0;
+    //Sets current filename
+    virtual void filename(std::string /* fname */) {};
 
-        //Sets current line number
-        virtual void lineno(int line_num) = 0;
+    //Sets current line number
+    virtual void lineno(int /* line_num */) {};
 
-        //Start of a .model
-        virtual void begin_model(std::string model_name) = 0;
+    //Start of a .model
+    virtual void begin_model(std::string /* model_name */) {};
 
-        //.inputs
-        virtual void inputs(std::vector<std::string> inputs) = 0;
+    //.inputs
+    virtual void inputs(std::vector<std::string> /* inputs */) {};
 
-        //.outputs
-        virtual void outputs(std::vector<std::string> outputs) = 0;
+    //.outputs
+    virtual void outputs(std::vector<std::string> /* outputs */) {};
 
-        //.names
-        virtual void names(std::vector<std::string> nets, std::vector<std::vector<LogicValue>> so_cover) = 0;
+    //.names
+    virtual void names(std::vector<std::string> /* nets */, std::vector<std::vector<LogicValue>> /* so_cover */) {};
 
-        //.latch
-        virtual void latch(std::string input, std::string output, LatchType type, std::string control, LogicValue init) = 0;
+    //.latch
+    virtual void latch(std::string /* input */, std::string /* output */, LatchType /* type */, std::string /* control */, LogicValue /* init */) {};
 
-        //.subckt
-        virtual void subckt(std::string model, std::vector<std::string> ports, std::vector<std::string> nets) = 0;
+    //.subckt
+    virtual void subckt(std::string /* model */, std::vector<std::string> /* ports */, std::vector<std::string> /* nets */) {};
 
-        //.blackbox
-        virtual void blackbox() = 0;
+    //.blackbox
+    virtual void blackbox() {};
 
-        //.end (of a .model)
-        virtual void end_model() = 0;
+    //.end (of a .model)
+    virtual void end_model() {};
 
-        //.conn [Extended BLIF, produces an error if not overriden]
-        virtual void conn(std::string src, std::string dst);
+    //.conn [Extended BLIF : Default throws an error]
+    virtual void conn(std::string src, std::string dst);
 
-        //.cname [Extended BLIF, produces an error if not overriden]
-        virtual void cname(std::string cell_name);
+    //.cname [Extended BLIF : Default throws an error]
+    virtual void cname(std::string cell_name);
 
-        //.attr [Extended BLIF, produces an error if not overriden]
-        virtual void attr(std::string name, std::string value);
+    //.attr [Extended BLIF : Default throws an error]
+    virtual void attr(std::string name, std::string value);
 
-        //.param [Extended BLIF, produces an error if not overriden]
-        virtual void param(std::string name, std::string value);
+    //.param [Extended BLIF : Default throws an error]
+    virtual void param(std::string name, std::string value);
 
-        //End of parsing
-        virtual void finish_parse() = 0;
+    //End of parsing
+    virtual void finish_parse() {};
 
-        //Error during parsing
-        virtual void parse_error(const int curr_lineno, const std::string& near_text, const std::string& msg) = 0;
-};
+    //Error during parsing
+    virtual void parse_error(const int /* curr_lineno */, const std::string& /* near_text */, const std::string& /* msg */) {};
+  };
 
+  /*
+   * Overrides the above with a test for parsing errors that is available afterwards
+   */
+  class ParseErrorCallback : public Callback {
+  public:
+    void parse_error(const int curr_lineno, const std::string& near_text, const std::string& msg) override {
+      fprintf(stderr, "Custom Error at line %d near '%s': %s\n", curr_lineno, near_text.c_str(), msg.c_str());
+      had_error_ = true;
+    }
 
-/*
- * External functions for loading an SDC file
- */
-void blif_parse_filename(std::string filename, Callback& callback);
-void blif_parse_filename(const char* filename, Callback& callback);
+    bool had_error() { return had_error_ = true; }
 
-//Loads from 'blif'. 'filename' only used to pass a filename to callback and can be left unspecified
-void blif_parse_file(FILE* blif, Callback& callback, const char* filename=""); 
+  private:
+    bool had_error_ = false;
+  };
 
-/*
- * Enumerations
- */
-enum class LogicValue {
+  /*
+   * External functions for loading an SDC file
+   */
+  void blif_parse_filename(std::string filename, Callback& callback);
+  void blif_parse_filename(const char* filename, Callback& callback);
+
+  //Loads from 'blif'. 'filename' only used to pass a filename to callback and can be left unspecified
+  void blif_parse_file(FILE* blif, Callback& callback, const char* filename="");
+
+  /*
+   * Enumerations
+   */
+  enum class LogicValue {
     FALSE = 0,  // Logic zero
     TRUE = 1,   // Logic one
     DONT_CARE,  // Don't care
     UNKNOWN     // Unknown (e.g. latch initial state)
-};
+  };
 
-enum class LatchType {
+  enum class LatchType {
     FALLING_EDGE,
     RISING_EDGE,
     ACTIVE_HIGH,
     ACTIVE_LOW,
     ASYNCHRONOUS,
-    UNSPECIFIED //If no type is specified
-};
+    UNSPECIFIED  //If no type is specified
+  };
 
-} //namespace
+} // blifparse
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,57 +6,22 @@
 
 using namespace blifparse;
 
-int exit_code = 0;
-
-class NoOpCallback : public Callback {
-    //A No-op version of the callback
-    public:
-        void start_parse() override {}
-
-        void filename(std::string /*fname*/) override {}
-        void lineno(int /*line_num*/) override {}
-
-        void begin_model(std::string /*model_name*/) override {}
-        void inputs(std::vector<std::string> /*inputs*/) override {}
-        void outputs(std::vector<std::string> /*outputs*/) override {}
-
-        void names(std::vector<std::string> /*nets*/, std::vector<std::vector<LogicValue>> /*so_cover*/) override {}
-        void latch(std::string /*input*/, std::string /*output*/, LatchType /*type*/, std::string /*control*/, LogicValue /*init*/) override {}
-        void subckt(std::string /*model*/, std::vector<std::string> /*ports*/, std::vector<std::string> /*nets*/) override {}
-        void blackbox() override {}
-
-        void end_model() override {}
-
-        void finish_parse() override {}
-
-        void parse_error(const int curr_lineno, const std::string& near_text, const std::string& msg) override {
-            fprintf(stderr, "Custom Error at line %d near '%s': %s\n", curr_lineno, near_text.c_str(), msg.c_str());
-            had_error_ = true;
-        }
-
-        bool had_error() { return had_error_ = true; }
-
-    private:
-        bool had_error_ = false;
-};
-
 int main(int argc, char **argv) {
-    if(argc != 2) {
-        fprintf(stderr, "Usage: %s filename.blif\n", argv[0]);
-        fprintf(stderr, "\n");
-        fprintf(stderr, "Reads in an blif file into internal data structures\n");
-        fprintf(stderr, "and then prints it out\n");
-        exit(1);
-    }
+  if(argc != 2) {
+    fprintf(stderr, "Usage: %s filename.blif\n", argv[0]);
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Reads in an blif file into internal data structures\n");
+    fprintf(stderr, "and then prints it out\n");
+    exit(1);
+  }
 
-    //Parse the file
-    blifparse::BlifPrettyPrinter callback(true);
-    //NoOpCallback callback;
-    blif_parse_filename(argv[1], callback);
+  //Parse the file
+  blifparse::BlifPrettyPrinter callback(true);
+  blif_parse_filename(argv[1], callback);
 
-    if(callback.had_error()) {
-        return 1;
-    } else {
-        return 0;
-    }
+  if(callback.had_error()) {
+    return 1;
+  } else {
+    return 0;
+  }
 }


### PR DESCRIPTION
- Fixes spelling error of *unknown* (the second *n* is missing); this is a breaking change.
- Fixes some spelling errors in comments.
- Makes the default implementation of the *Callback* class lots of *noops*. This way, one only has to overload/implement the few relevant functions.