### PR TITLE
Fix 'parser_class_name' is deprecated

### DIFF
--- a/src/blif_parser.y
+++ b/src/blif_parser.y
@@ -34,7 +34,7 @@
 %define api.namespace {blifparse}
 
 /* Name the parser class */
-%define parser_class_name {Parser}
+%define api.parser.class {Parser}
 
 /* Match the flex prefix */
 %define api.prefix {blifparse_}


### PR DESCRIPTION
Fixes the following warning:
```
blifparse/src/blif_parser.y:37.1-34: warning: deprecated directive: ‘%define parser_class_name {Parser}’, use ‘%define api.parser.class {Parser}’ [-Wdeprecated]
   37 | %define parser_class_name {Parser}
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      | %define api.parser.class {Parser}
/home/soelvsten/git/bdd-benchmark/external/blifparse/src/blif_parser.y: warning: fix-its can be applied.  Rerun with option '--update'. [-Wother]
```